### PR TITLE
Fix authenticated POST

### DIFF
--- a/digestAuthRequest.js
+++ b/digestAuthRequest.js
@@ -137,7 +137,7 @@ function digestAuthRequest(method, url, username, password) {
 		// if we are posting, add appropriate headers
 		if (self.post) {
 			self.request.setRequestHeader('Content-type', 'application/json');
-			self.request.setRequestHeader('Content-length', data.length);
+			self.request.setRequestHeader('Content-length', self.data.length);
 			self.request.setRequestHeader('Connection', 'close');
 		}
 		self.request.onload = function() {


### PR DESCRIPTION
'data' could not be found, at least under chrome, without the 'self.' prefix.
