### PR TITLE
log status code for the first (unauthenticated) request on request error

### DIFF
--- a/digestAuthRequest.js
+++ b/digestAuthRequest.js
@@ -140,7 +140,7 @@ function digestAuthRequest(method, url, username, password) {
 		// handle error
 		self.firstRequest.onerror = function() {
 			if (self.firstRequest.status !== 401) {
-				self.log('Error ('+self.authenticatedRequest.status+') on unauthenticated request to '+url);
+				self.log('Error ('+self.firstRequest.status+') on unauthenticated request to '+url);
 				self.errorFn(self.firstRequest.status);
 			}
 		}


### PR DESCRIPTION
Fix a bug where trying to get status code from the wrong request object.
This resolved in an exception, causing 'error handler' to not be called.