### PR TITLE
Improve tolerance when carriage returns may not be present in the hea…

### DIFF
--- a/digestAuthRequest.js
+++ b/digestAuthRequest.js
@@ -74,7 +74,7 @@ var digestAuthRequest = function (method, url, username, password) {
 
 				if (digestHeaders != null) {
 					// parse auth header and get digest auth keys
-					digestHeaders = digestHeaders.slice(digestHeaders.indexOf(':') + 1, -1);
+					digestHeaders = digestHeaders.slice(digestHeaders.indexOf(':') + 1).replace(/\r/g, '');
 					digestHeaders = digestHeaders.split(',');
 					self.scheme = digestHeaders[0].split(/\s/)[1];
 					for (var i = 0; i < digestHeaders.length; i++) {


### PR DESCRIPTION
I ran into a problem with react native on iOS when using the debugger where under some conditions, there was no carriage return in the headers, just a newline.  This resulted in the last character of the nonce being removed, and all of the hashes were wrong.

This patch improves the tolerance allowing for carriage returns to be either present or absent, and the nonce will be preserved properly.