### PR TITLE
Fix header matching

### DIFF
--- a/digestAuthRequest.js
+++ b/digestAuthRequest.js
@@ -69,6 +69,7 @@ var digestAuthRequest = function (method, url, username, password) {
 				for(var i = 0; i < responseHeaders.length; i++) {
 					if (responseHeaders[i].match(/^www-authenticate:/i) != null) {
 						digestHeaders = responseHeaders[i];
+						break;
 					}
 				}
 

--- a/digestAuthRequest.js
+++ b/digestAuthRequest.js
@@ -67,7 +67,7 @@ var digestAuthRequest = function (method, url, username, password) {
 				// get authenticate header
 				var digestHeaders;
 				for(var i = 0; i < responseHeaders.length; i++) {
-					if (responseHeaders[i].match(/www-authenticate/i) != null) {
+					if (responseHeaders[i].match(/^www-authenticate:/i) != null) {
 						digestHeaders = responseHeaders[i];
 					}
 				}


### PR DESCRIPTION
In electron 3.1.12 it turned out the header `access-control-expose-headers: www-authenticate` is also present when you do `getAllResponseHeaders()`. It comes later then the `www-authenticate: digest.. ` so it is matched inside the for loop, hence the values from the header can't be parsed.

Besides the improved matching, which ensures the right header, we can also break out of the loop if we found the match as there is no need to look further.